### PR TITLE
Feature/generate route with forbidden edges

### DIFF
--- a/backend/src/main/java/osmproxy/AvoidEdgesRemovableWeighting.java
+++ b/backend/src/main/java/osmproxy/AvoidEdgesRemovableWeighting.java
@@ -1,0 +1,37 @@
+package osmproxy;
+
+import java.util.Collection;
+
+import com.graphhopper.routing.weighting.AvoidEdgesWeighting;
+import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.util.EdgeIteratorState;
+
+import gnu.trove.set.TIntSet;
+
+public class AvoidEdgesRemovableWeighting extends AvoidEdgesWeighting {
+
+	public static final String NAME = "avoid_edges_removable";
+
+	public AvoidEdgesRemovableWeighting(Weighting superWeighting) {
+		super(superWeighting);
+	}
+
+    /**
+     * This method removes the specified path to this weighting which should be penalized in the
+     * calcWeight method.
+     */
+    public void removeEdges(Collection<EdgeIteratorState> edges) {
+        for (EdgeIteratorState edge : edges) {
+            visitedEdges.remove(edge.getEdge());
+        }
+    }
+
+    public final TIntSet getEdges() {
+    	return visitedEdges;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/backend/src/main/java/osmproxy/HighwayAccessor.java
+++ b/backend/src/main/java/osmproxy/HighwayAccessor.java
@@ -24,10 +24,15 @@ import com.graphhopper.routing.VirtualEdgeIteratorState;
 import com.graphhopper.util.CmdArgs;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PointList;
+
+import gnu.trove.set.TIntSet;
+
 import org.javatuples.Pair;
 import routing.nodes.RouteNode;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -47,16 +52,19 @@ public class HighwayAccessor {
         graphHopper.init(CmdArgs.read(args));
         graphHopper.importOrLoad();
     }
+    
+    // TODO: tested manually, but add unit tests / integration tests
 
     public static Pair<List<Long>, List<RouteNode>> getOsmWayIdsAndPointList(double fromLat, double fromLon,
-                                                                             double toLat, double toLon,
-                                                                             boolean onFoot) {
+            double toLat, double toLon, boolean onFoot) {
         List<Long> osmWayIds = new ArrayList<>();
         List<RouteNode> pointList = new ArrayList<>();
 
         GHResponse response = new GHResponse();
-        List<Path> paths = graphHopper.calcPaths(new GHRequest(fromLat, fromLon, toLat, toLon).
-                setWeighting("fastest").setVehicle(onFoot ? "foot" : "car"), response);
+        GHRequest request = new GHRequest(fromLat, fromLon, toLat, toLon)
+        		.setVehicle(onFoot ? "foot" : "car")
+        		.setWeighting(AvoidEdgesRemovableWeighting.NAME);
+        List<Path> paths = graphHopper.calcPaths(request, response);
         Path path0 = paths.get(0);
 
         long previousWayId = 0;
@@ -76,7 +84,6 @@ public class HighwayAccessor {
             }
 
             pointList.addAll(getRouteNodeList(edge.fetchWayGeometry(2)));
-
         }
 
         return new Pair<>(osmWayIds, pointList);


### PR DESCRIPTION
The feature supplements the ExtendedGraphHopper class with the ability to forbid given edges for route generation:

![image](https://user-images.githubusercontent.com/41029533/96301032-db447400-0ff6-11eb-98fc-654c5ec8e337.png)

Thanks to the interface, it is possible to point the exact point through which the object should not be routed, thus alternative route -- not the fastest one -- shall be created.